### PR TITLE
Added support for Python3.

### DIFF
--- a/tests/verbal_expressions_test.py
+++ b/tests/verbal_expressions_test.py
@@ -145,4 +145,4 @@ class VerExTest(unittest.TestCase):
 
     def test_should_match_url(self):
         self.exp = self.v.start_of_line().then('http').maybe('s').then('://').maybe('www.').word().then('.').word().maybe('/').end_of_line().regex()
-        self._assertRegex('https://www.google.com/', self.exp, 'Not a valid email')
+        self._assertRegex('https://www.google.com/', self.exp, 'Not a valid url')

--- a/tests/verbal_expressions_test.py
+++ b/tests/verbal_expressions_test.py
@@ -2,6 +2,7 @@
 import unittest
 from verbalexpressions import VerEx
 import re
+import sys
 
 class VerExTest(unittest.TestCase):
     '''
@@ -11,94 +12,104 @@ class VerExTest(unittest.TestCase):
     def setUp(self):
         self.v = VerEx()
 
+        # Unit Test assertRegexpMatches functions renamed in version 3.2
+        if sys.version_info > (3, 1):
+            self._assertRegex = self.assertRegex
+            self._assertNotRegex = self.assertNotRegex
+        else:
+            self._assertRegex = self.assertRegexpMatches
+            self._assertNotRegex = self.assertNotRegexpMatches
+
     def tearDown(self):
         self.v = None
         self.exp = None
+        self._assertRegex = None
+        self._assertNotRegex = None
 
     def test_should_render_verex_as_string(self):
-        self.assertEquals(str(self.v.add('^$')), '^$')
+        self.assertEqual(str(self.v.add('^$')), '^$')
 
     def test_should_match_characters_in_range(self):
         self.exp = self.v.start_of_line().range('a', 'c').regex()
         for character in ['a', 'b', 'c']:
-            self.assertRegexpMatches(character, self.exp)
+            self._assertRegex(character, self.exp)
 
     def test_should_not_match_characters_outside_of_range(self):
         self.exp = self.v.start_of_line().range('a', 'c').regex()
-        self.assertNotRegexpMatches('d', self.exp)
+        self._assertNotRegex('d', self.exp)
 
     def test_should_match_characters_in_extended_range(self):
         self.exp = self.v.start_of_line().range('a', 'b', 'X', 'Z').regex()
         for character in ['a', 'b']:
-            self.assertRegexpMatches(character, self.exp)
+            self._assertRegex(character, self.exp)
         for character in ['X', 'Y', 'Z']:
-            self.assertRegexpMatches(character, self.exp)
+            self._assertRegex(character, self.exp)
 
     def test_should_not_match_characters_outside_of_extended_range(self):
         self.exp = self.v.start_of_line().range('a', 'b', 'X', 'Z').regex()
-        self.assertNotRegexpMatches('c', self.exp)
-        self.assertNotRegexpMatches('W', self.exp)
+        self._assertNotRegex('c', self.exp)
+        self._assertNotRegex('W', self.exp)
 
 
     def test_should_match_start_of_line(self):
         self.exp = self.v.start_of_line().regex()
-        self.assertRegexpMatches('text  ', self.exp, 'Not started :(')
+        self._assertRegex('text  ', self.exp, 'Not started :(')
 
     def test_should_match_end_of_line(self):
         self.exp = self.v.start_of_line().end_of_line().regex()
-        self.assertRegexpMatches('', self.exp, 'It\'s not the end!')
+        self._assertRegex('', self.exp, 'It\'s not the end!')
 
     def test_should_match_anything(self):
         self.exp = self.v.start_of_line().anything().end_of_line().regex()
-        self.assertRegexpMatches('!@#$%¨&*()__+{}', self.exp, 'Not so anything...')
+        self._assertRegex('!@#$%¨&*()__+{}', self.exp, 'Not so anything...')
 
     def test_should_match_anything_but_specified_element_when_element_is_not_found(self):
         self.exp = self.v.start_of_line().anything_but('X').end_of_line().regex()
-        self.assertRegexpMatches('Y Files', self.exp, 'Found the X!')
+        self._assertRegex('Y Files', self.exp, 'Found the X!')
 
     def test_should_not_match_anything_but_specified_element_when_specified_element_is_found(self):
         self.exp = self.v.start_of_line().anything_but('X').end_of_line().regex()
-        self.assertNotRegexpMatches('VerEX', self.exp, 'Didn\'t found the X :(')
+        self._assertNotRegex('VerEX', self.exp, 'Didn\'t found the X :(')
 
     def test_should_find_element(self):
         self.exp = self.v.start_of_line().find('Wally').end_of_line().regex()
-        self.assertRegexpMatches('Wally', self.exp, '404! Wally not Found!')
+        self._assertRegex('Wally', self.exp, '404! Wally not Found!')
 
     def test_should_not_find_missing_element(self):
         self.exp = self.v.start_of_line().find('Wally').end_of_line().regex()
-        self.assertNotRegexpMatches('Wall-e', self.exp, 'DAFUQ is Wall-e?')
+        self._assertNotRegex('Wall-e', self.exp, 'DAFUQ is Wall-e?')
 
     def test_should_match_when_maybe_element_is_present(self):
         self.exp = self.v.start_of_line().find('Python2.').maybe('7').end_of_line().regex()
-        self.assertRegexpMatches('Python2.7', self.exp, 'Version doesn\'t match!')
+        self._assertRegex('Python2.7', self.exp, 'Version doesn\'t match!')
 
     def test_should_match_when_maybe_element_is_missing(self):
         self.exp = self.v.start_of_line().find('Python2.').maybe('7').end_of_line().regex()
-        self.assertRegexpMatches('Python2.', self.exp, 'Version doesn\'t match!')
+        self._assertRegex('Python2.', self.exp, 'Version doesn\'t match!')
 
     def test_should_match_on_any_when_element_is_found(self):
         self.exp = self.v.start_of_line().any('Q').anything().end_of_line().regex()
-        self.assertRegexpMatches('Query', self.exp, 'No match found!')
+        self._assertRegex('Query', self.exp, 'No match found!')
 
     def test_should_not_match_on_any_when_element_is_not_found(self):
         self.exp = self.v.start_of_line().any('Q').anything().end_of_line().regex()
-        self.assertNotRegexpMatches('W', self.exp, 'I\'ve found it!')
+        self._assertNotRegex('W', self.exp, 'I\'ve found it!')
 
     def test_should_match_when_line_break_present(self):
         self.exp = self.v.start_of_line().anything().line_break().anything().end_of_line().regex()
-        self.assertRegexpMatches('Marco \n Polo', self.exp, 'Give me a break!!')
+        self._assertRegex('Marco \n Polo', self.exp, 'Give me a break!!')
 
     def test_should_match_when_line_break_and_carriage_return_present(self):
         self.exp = self.v.start_of_line().anything().line_break().anything().end_of_line().regex()
-        self.assertRegexpMatches('Marco \r\n Polo', self.exp, 'Give me a break!!')
+        self._assertRegex('Marco \r\n Polo', self.exp, 'Give me a break!!')
 
     def test_should_not_match_when_line_break_is_missing(self):
         self.exp = self.v.start_of_line().anything().line_break().anything().end_of_line().regex()
-        self.assertNotRegexpMatches('Marco Polo', self.exp, 'There\'s a break here!')
+        self._assertNotRegex('Marco Polo', self.exp, 'There\'s a break here!')
 
     def test_should_match_when_tab_present(self):
         self.exp = self.v.start_of_line().anything().tab().end_of_line().regex()
-        self.assertRegexpMatches('One tab only	', self.exp, 'No tab here!')
+        self._assertRegex('One tab only	', self.exp, 'No tab here!')
 
     def test_should_not_match_when_tab_is_missing(self):
         self.exp = self.v.start_of_line().anything().tab().end_of_line().regex()
@@ -106,7 +117,7 @@ class VerExTest(unittest.TestCase):
 
     def test_should_match_when_word_present(self):
         self.exp = self.v.start_of_line().anything().word().end_of_line().regex()
-        self.assertRegexpMatches('Oneword', self.exp, 'Not just a word!')
+        self._assertRegex('Oneword', self.exp, 'Not just a word!')
 
     def test_not_match_when_two_words_are_present_instead_of_one(self):
         self.exp = self.v.start_of_line().anything().tab().end_of_line().regex()
@@ -114,7 +125,7 @@ class VerExTest(unittest.TestCase):
 
     def test_should_match_when_or_condition_fulfilled(self):
         self.exp = self.v.start_of_line().anything().find('G').OR().find('h').end_of_line().regex()
-        self.assertRegexpMatches('Github', self.exp, 'Octocat not found')
+        self._assertRegex('Github', self.exp, 'Octocat not found')
 
     def test_should_not_match_when_or_condition_not_fulfilled(self):
         self.exp = self.v.start_of_line().anything().find('G').OR().find('h').end_of_line().regex()
@@ -122,16 +133,16 @@ class VerExTest(unittest.TestCase):
 
     def test_should_match_on_upper_case_when_lower_case_is_given_and_any_case_is_true(self):
         self.exp = self.v.start_of_line().find('THOR').end_of_line().with_any_case(True).regex()
-        self.assertRegexpMatches('thor', self.exp, 'Upper case Thor, please!')
+        self._assertRegex('thor', self.exp, 'Upper case Thor, please!')
 
     def test_should_match_multiple_lines(self):
         self.exp = self.v.start_of_line().anything().find('Pong').anything().end_of_line().search_one_line(True).regex()
-        self.assertRegexpMatches('Ping \n Pong \n Ping', self.exp, 'Pong didn\'t answer')
+        self._assertRegex('Ping \n Pong \n Ping', self.exp, 'Pong didn\'t answer')
 
     def test_should_match_email_address(self):
         self.exp = self.v.start_of_line().word().then('@').word().then('.').word().end_of_line().regex()
-        self.assertRegexpMatches('mail@mail.com', self.exp, 'Not a valid email')
+        self._assertRegex('mail@mail.com', self.exp, 'Not a valid email')
 
     def test_should_match_url(self):
         self.exp = self.v.start_of_line().then('http').maybe('s').then('://').maybe('www.').word().then('.').word().maybe('/').end_of_line().regex()
-        self.assertRegexpMatches('https://www.google.com/', self.exp, 'Not a valid email')
+        self._assertRegex('https://www.google.com/', self.exp, 'Not a valid email')

--- a/verbalexpressions/__init__.py
+++ b/verbalexpressions/__init__.py
@@ -1,1 +1,1 @@
-from verbal_expressions import VerEx, re_escape
+from .verbal_expressions import VerEx, re_escape

--- a/verbalexpressions/verbal_expressions.py
+++ b/verbalexpressions/verbal_expressions.py
@@ -13,10 +13,8 @@ class VerEx(object):
     --- VerbalExpressions class ---
     the following methods behave different from the original js lib!
 
-    - end_of_line
-    - start_of_line
     - or
-    when you say you want `$`, `^` and `|`, we just insert it right there.
+    when you say you want `|`, we just insert it right there.
     No other tricks.
 
     And any string you inserted will be automatically grouped
@@ -24,6 +22,8 @@ class VerEx(object):
     '''
     def __init__(self):
         self.s = ''
+        self._start_of_line = False
+        self._end_of_line = False
         self.modifiers = {'I': 0, 'M': 0}
 
     def __getattr__(self, attr):
@@ -39,8 +39,16 @@ class VerEx(object):
         return self
 
     def regex(self):
+        regex_string = self.s
+        
+        if self._start_of_line:
+          regex_string = '^' + regex_string
+
+        if self._end_of_line:
+          regex_string += '$' 
+
         ''' get a regular expression object. '''
-        return re.compile(self.s, self.modifiers['I'] | self.modifiers['M'])
+        return re.compile(regex_string, self.modifiers['I'] | self.modifiers['M'])
     compile = regex
 
     def source(self):
@@ -58,14 +66,16 @@ class VerEx(object):
         return self.add('([^' + value + ']*)')
 
     def end_of_line(self):
-        return self.add('$')
+        self._end_of_line = True
+        return self
 
     @re_escape
     def maybe(self, value):
         return self.add("(" + value + ")?")
 
     def start_of_line(self):
-        return self.add('^')
+        self._start_of_line = True
+        return self
 
     @re_escape
     def find(self, value):


### PR DESCRIPTION
The verbalexpressions \_\_init\_\_.py has been modified to include explicit relative imports (as implicit relative imports has been removed for Python3).

Unit Tests have been modified to cope with the rename of assertRegexpMatches in unittest version 3.2.

I have tested these changes with Python v2.7.6 and Python v3.3.5