### PR TITLE
python 3.5 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,23 +4,22 @@ from setuptools import setup
 
 if __name__ == '__main__':
     setup(
-          name = 'VerbalExpressions',
-          version = '0.0.1',
-          description = 'Make difficult regular expressions easy! Python port of the awesome VerbalExpressions repo - https://github.com/jehna/VerbalExpressions',
-          long_description = '''Please see https://github.com/VerbalExpressions/PythonVerbalExpressions/blob/master/README.md for more information!''',
-          author = "Yan Wenjun, diogobeda, Mihai Ionut Vilcu, Peder Soholt",
-          author_email = "",
-          license = 'MIT',
-          url = 'https://github.com/VerbalExpressions/PythonVerbalExpressions',
-          test_suite='tests',
-          scripts = [],
-          packages = ['verbalexpressions'],
-          classifiers = [
-                          'License :: OSI Approved :: MIT License',
-                          'Programming Language :: Python',
-                          'Topic :: Software Development :: Libraries',
-                          'Topic :: Text Processing'
-                        ],
-          zip_safe=True
+        name='VerbalExpressions',
+        version='0.0.2',
+        description='Make difficult regular expressions easy! Python port of the awesome VerbalExpressions repo - https://github.com/jehna/VerbalExpressions',
+        long_description='''Please see https://github.com/VerbalExpressions/PythonVerbalExpressions/blob/master/README.md for more information!''',
+        author="Yan Wenjun, diogobeda, Mihai Ionut Vilcu, Peder Soholt, Kharms",
+        author_email="",
+        license='MIT',
+        url='https://github.com/VerbalExpressions/PythonVerbalExpressions',
+        test_suite='tests',
+        scripts=[],
+        packages=['verbalexpressions'],
+        classifiers=[
+            'License :: OSI Approved :: MIT License',
+            'Programming Language :: Python',
+            'Topic :: Software Development :: Libraries',
+            'Topic :: Text Processing'
+        ],
+        zip_safe=True
     )
-

--- a/tests/verbal_expressions_test.py
+++ b/tests/verbal_expressions_test.py
@@ -3,10 +3,11 @@ import unittest
 from verbalexpressions import VerEx
 import re
 
+
 class VerExTest(unittest.TestCase):
-    '''
+    """
         Tests for verbal_expressions.py
-    '''
+    """
 
     def setUp(self):
         self.v = VerEx()
@@ -136,5 +137,6 @@ class VerExTest(unittest.TestCase):
         self.assertRegexpMatches('mail@mail.com', self.exp, 'Not a valid email')
 
     def test_should_match_url(self):
-        self.exp = self.v.start_of_line().then('http').maybe('s').then('://').maybe('www.').word().then('.').word().maybe('/').end_of_line().regex()
+        self.exp = self.v.start_of_line().then('http').maybe('s').then('://').maybe('www.').word().then('.').word()\
+            .maybe('/').end_of_line().regex()
         self.assertRegexpMatches('https://www.google.com/', self.exp, 'Not a valid email')

--- a/verbalexpressions/__init__.py
+++ b/verbalexpressions/__init__.py
@@ -1,1 +1,1 @@
-from verbal_expressions import VerEx, re_escape
+from .verbal_expressions import VerEx, re_escape


### PR DESCRIPTION
Behavior in 2.7 is unchanged. 3.5 mimics 2.7 in full with the exception
of defaulting to unicode instead of ascii. an ascii flag/modifier was
added to mimic old behavior.
