### PR TITLE
fixed the module not found error for Python 3.0 and later

### DIFF
--- a/verbalexpressions/__init__.py
+++ b/verbalexpressions/__init__.py
@@ -1,1 +1,1 @@
-from verbal_expressions import VerEx, re_escape
+from .verbal_expressions import VerEx, re_escape


### PR DESCRIPTION
There is a import error on some python versions. See [issue](https://github.com/VerbalExpressions/PythonVerbalExpressions/issues/27) for more.